### PR TITLE
fix(projects): HALP-7462 getByExternalId should return array

### DIFF
--- a/src/lib/projects/projects.test.ts
+++ b/src/lib/projects/projects.test.ts
@@ -1,7 +1,29 @@
 import { Projects } from './projects'
+import { axiosMock } from '../../../__fixtures__/axios'
+import { TimelyProject } from '../types'
 
 describe('Projects', () => {
-    it('creates', () => {
-        expect(new Projects({} as never, {} as never)).toBeTruthy()
+    let projects: Projects
+
+    beforeEach(
+        () => (projects = new Projects(axiosMock, { token: 'token', accountId: 'accountId' })),
+    )
+
+    describe('getByExternalId', () => {
+        it(`returns an empty array given getAll doesn't behave as expected`, async () => {
+            jest.spyOn(projects, 'getAll').mockResolvedValue({} as never)
+            await expect(projects.getByExternalId('CUST')).resolves.toEqual([])
+        })
+
+        it(`returns an empty array given no matches`, async () => {
+            jest.spyOn(projects, 'getAll').mockResolvedValue([{ external_id: 'NUNYA' } as never])
+            await expect(projects.getByExternalId('CUST')).resolves.toEqual([])
+        })
+
+        it(`returns matching projects`, async () => {
+            const p = [{ external_id: 'CUST' }] as never as TimelyProject[]
+            jest.spyOn(projects, 'getAll').mockResolvedValue(p)
+            await expect(projects.getByExternalId('CUST')).resolves.toEqual(p)
+        })
     })
 })

--- a/src/lib/projects/projects.ts
+++ b/src/lib/projects/projects.ts
@@ -21,10 +21,10 @@ export class Projects {
         return data
     }
 
-    async getByExternalId(externalId: string): Promise<TimelyProject | undefined> {
+    async getByExternalId(externalId: string): Promise<TimelyProject[]> {
         const projects = await this.getAll()
-        if (!(projects && projects.length)) return undefined
-        return projects.find((e) => e?.external_id === externalId)
+        if (!(projects && projects.length)) return []
+        return projects.filter((e) => e?.external_id === externalId)
     }
 
     async add(project: AddTimelyProject): Promise<TimelyProject> {


### PR DESCRIPTION
BREAKING CHANGE: projects.getByExternalId was returning a single project matching the given id, which would be the first returned. This updates the method to return all matching projects.