### PR TITLE
refactor(projects): XXX-0 improve speed, reduce timeouts from timely

### DIFF
--- a/src/lib/projects/projects.test.ts
+++ b/src/lib/projects/projects.test.ts
@@ -1,29 +1,161 @@
 import { Projects } from './projects'
 import { axiosMock } from '../../../__fixtures__/axios'
-import { TimelyProject } from '../types'
+import { TimelyProject, TimelyProjectSummary } from '../types'
+
+const ACCOUNT_ID = 'accountId'
 
 describe('Projects', () => {
     let projects: Projects
 
-    beforeEach(
-        () => (projects = new Projects(axiosMock, { token: 'token', accountId: 'accountId' })),
-    )
+    beforeEach(() => {
+        projects = new Projects(axiosMock, { token: 'token', accountId: ACCOUNT_ID })
+    })
+
+    afterEach(() => {
+        jest.clearAllMocks()
+    })
+
+    describe('getAll', () => {
+        it('defaults to active state with totals', async () => {
+            axiosMock.get.mockResolvedValue({ data: [] })
+            await projects.getAll()
+            expect(axiosMock.get).toHaveBeenCalledWith(
+                `/${ACCOUNT_ID}/projects?state=active&totals=true`,
+            )
+        })
+
+        it('passes the given state', async () => {
+            axiosMock.get.mockResolvedValue({ data: [] })
+            await projects.getAll('all')
+            expect(axiosMock.get).toHaveBeenCalledWith(
+                `/${ACCOUNT_ID}/projects?state=all&totals=true`,
+            )
+        })
+
+        it('passes totals=false when includeTotals is false', async () => {
+            axiosMock.get.mockResolvedValue({ data: [] })
+            await projects.getAll('active', false)
+            expect(axiosMock.get).toHaveBeenCalledWith(
+                `/${ACCOUNT_ID}/projects?state=active&totals=false`,
+            )
+        })
+
+        it('returns TimelyProject[] when includeTotals is true', async () => {
+            const mockProjects = [{ id: 1 }] as TimelyProject[]
+            axiosMock.get.mockResolvedValue({ data: mockProjects })
+            const result: TimelyProject[] = await projects.getAll()
+            expect(result).toEqual(mockProjects)
+        })
+
+        it('returns TimelyProjectSummary[] when includeTotals is false', async () => {
+            const mockProjects = [{ id: 1 }] as TimelyProjectSummary[]
+            axiosMock.get.mockResolvedValue({ data: mockProjects })
+            const result: TimelyProjectSummary[] = await projects.getAll('active', false)
+            expect(result).toEqual(mockProjects)
+        })
+    })
+
+    describe('getArchived', () => {
+        it('defaults to excluding totals', async () => {
+            axiosMock.get.mockResolvedValue({ data: [] })
+            await projects.getArchived()
+            expect(axiosMock.get).toHaveBeenCalledWith(
+                `/${ACCOUNT_ID}/projects?state=archived&totals=false`,
+            )
+        })
+
+        it('passes totals=false when includeTotals is false', async () => {
+            axiosMock.get.mockResolvedValue({ data: [] })
+            await projects.getArchived(false)
+            expect(axiosMock.get).toHaveBeenCalledWith(
+                `/${ACCOUNT_ID}/projects?state=archived&totals=false`,
+            )
+        })
+
+        it('passes totals=true when includeTotals is true', async () => {
+            axiosMock.get.mockResolvedValue({ data: [] })
+            await projects.getArchived(true)
+            expect(axiosMock.get).toHaveBeenCalledWith(
+                `/${ACCOUNT_ID}/projects?state=archived&totals=true`,
+            )
+        })
+
+        it('returns TimelyProjectSummary[] by default', async () => {
+            const mockProjects = [{ id: 2, active: false }] as TimelyProjectSummary[]
+            axiosMock.get.mockResolvedValue({ data: mockProjects })
+            const result: TimelyProjectSummary[] = await projects.getArchived()
+            expect(result).toEqual(mockProjects)
+        })
+
+        it('returns TimelyProject[] when includeTotals is true', async () => {
+            const mockProjects = [{ id: 2, active: false }] as TimelyProject[]
+            axiosMock.get.mockResolvedValue({ data: mockProjects })
+            const result: TimelyProject[] = await projects.getArchived(true)
+            expect(result).toEqual(mockProjects)
+        })
+    })
 
     describe('getByExternalId', () => {
-        it(`returns an empty array given getAll doesn't behave as expected`, async () => {
-            jest.spyOn(projects, 'getAll').mockResolvedValue({} as never)
-            await expect(projects.getByExternalId('CUST')).resolves.toEqual([])
+        it('defaults to including totals', async () => {
+            axiosMock.get.mockResolvedValue({ data: [] })
+            await projects.getByExternalId('CUST')
+            expect(axiosMock.get).toHaveBeenCalledWith(
+                `/${ACCOUNT_ID}/projects?state=active&external_ids=CUST&totals=true`,
+            )
         })
 
-        it(`returns an empty array given no matches`, async () => {
-            jest.spyOn(projects, 'getAll').mockResolvedValue([{ external_id: 'NUNYA' } as never])
-            await expect(projects.getByExternalId('CUST')).resolves.toEqual([])
+        it('passes totals=false when includeTotals is false', async () => {
+            axiosMock.get.mockResolvedValue({ data: [] })
+            await projects.getByExternalId('CUST', false)
+            expect(axiosMock.get).toHaveBeenCalledWith(
+                `/${ACCOUNT_ID}/projects?state=active&external_ids=CUST&totals=false`,
+            )
         })
 
-        it(`returns matching projects`, async () => {
-            const p = [{ external_id: 'CUST' }] as never as TimelyProject[]
-            jest.spyOn(projects, 'getAll').mockResolvedValue(p)
-            await expect(projects.getByExternalId('CUST')).resolves.toEqual(p)
+        it('returns TimelyProject[] when includeTotals is true', async () => {
+            const mockProjects = [{ id: 3, external_id: 'CUST' }] as TimelyProject[]
+            axiosMock.get.mockResolvedValue({ data: mockProjects })
+            const result: TimelyProject[] = await projects.getByExternalId('CUST')
+            expect(result).toEqual(mockProjects)
+        })
+
+        it('returns TimelyProjectSummary[] when includeTotals is false', async () => {
+            const mockProjects = [{ id: 3, external_id: 'CUST' }] as TimelyProjectSummary[]
+            axiosMock.get.mockResolvedValue({ data: mockProjects })
+            const result: TimelyProjectSummary[] = await projects.getByExternalId('CUST', false)
+            expect(result).toEqual(mockProjects)
+        })
+    })
+
+    describe('getByProjectIds', () => {
+        it('defaults to including totals', async () => {
+            axiosMock.get.mockResolvedValue({ data: [] })
+            await projects.getByProjectIds([1, 2, 3])
+            expect(axiosMock.get).toHaveBeenCalledWith(
+                `/${ACCOUNT_ID}/projects?state=active&ids=1,2,3&totals=true`,
+            )
+        })
+
+        it('passes totals=false when includeTotals is false', async () => {
+            axiosMock.get.mockResolvedValue({ data: [] })
+            await projects.getByProjectIds([1, 2], false)
+            expect(axiosMock.get).toHaveBeenCalledWith(
+                `/${ACCOUNT_ID}/projects?state=active&ids=1,2&totals=false`,
+            )
+        })
+
+        it('returns TimelyProject[] when includeTotals is true', async () => {
+            const mockProjects = [{ id: 1 }] as TimelyProject[]
+            axiosMock.get.mockResolvedValue({ data: mockProjects })
+            const result: TimelyProject[] = await projects.getByProjectIds([1])
+            expect(result).toEqual(mockProjects)
+        })
+
+        it('returns TimelyProjectSummary[] when includeTotals is false', async () => {
+            const mockProjects = [{ id: 1 }] as TimelyProjectSummary[]
+            axiosMock.get.mockResolvedValue({ data: mockProjects })
+            const result: TimelyProjectSummary[] = await projects.getByProjectIds([1], false)
+            expect(result).toEqual(mockProjects)
         })
     })
 })

--- a/src/lib/projects/projects.ts
+++ b/src/lib/projects/projects.ts
@@ -1,5 +1,5 @@
 import { AxiosInstance } from 'axios'
-import { AddTimelyProject, TimelyAppConfig, TimelyProject } from '../types'
+import { AddTimelyProject, TimelyAppConfig, TimelyProject, TimelyProjectSummary } from '../types'
 
 export class Projects {
     constructor(
@@ -7,15 +7,46 @@ export class Projects {
         private readonly config: TimelyAppConfig,
     ) {}
 
-    async getAll(filter?: 'active' | 'all' | 'mine' | 'archived'): Promise<TimelyProject[]> {
+    /**
+     * Retrieves a list of projects based on the specified state and whether to include totals. Note:
+     * excluding totals makes this call *way* faster. Defaulting to including them to avoid breaking existing code.
+     *
+     * Overloaded: passing `includeTotals: false` narrows the return type to `TimelyProjectSummary[]`
+     * (totals fields absent), while omitting it or passing `true` returns `TimelyProject[]` (totals fields present).
+     *
+     * @param {('active'|'all'|'mine')} [state='active'] - The state of the projects to retrieve. Defaults to 'active' if not provided.
+     * @param {boolean} [includeTotals=true] - Indicates whether to include total values in the response. Defaults to true if not provided.
+     * @return {Promise<TimelyProject[]|TimelyProjectSummary[]>} A promise that resolves to an array of projects.
+     */
+    async getAll(state?: 'active' | 'all' | 'mine', includeTotals?: true): Promise<TimelyProject[]>
+    async getAll(
+        state: 'active' | 'all' | 'mine' | undefined,
+        includeTotals: false,
+    ): Promise<TimelyProjectSummary[]>
+    async getAll(
+        state?: 'active' | 'all' | 'mine',
+        includeTotals: boolean = true,
+    ): Promise<TimelyProject[] | TimelyProjectSummary[]> {
         const { data } = await this.http.get(
-            `/${this.config.accountId}/projects?filter=${filter ?? 'active'} `,
+            `/${this.config.accountId}/projects?state=${state ?? 'active'}&totals=${includeTotals}`,
         )
         return data
     }
 
-    async getArchived(): Promise<TimelyProject[]> {
-        const { data } = await this.http.get(`/${this.config.accountId}/projects?filter=archived`)
+    /**
+     * Retrieves archived projects. Defaults to excluding totals for performance — pass `true` to include them.
+     *
+     * Overloaded: omitting `includeTotals` or passing `false` returns `TimelyProjectSummary[]`;
+     * passing `true` returns `TimelyProject[]`.
+     */
+    async getArchived(includeTotals?: false): Promise<TimelyProjectSummary[]>
+    async getArchived(includeTotals: true): Promise<TimelyProject[]>
+    async getArchived(
+        includeTotals: boolean = false,
+    ): Promise<TimelyProject[] | TimelyProjectSummary[]> {
+        const { data } = await this.http.get(
+            `/${this.config.accountId}/projects?state=archived&totals=${includeTotals}`,
+        )
         return data
     }
 
@@ -24,10 +55,45 @@ export class Projects {
         return data
     }
 
-    async getByExternalId(externalId: string): Promise<TimelyProject[]> {
-        const projects = await this.getAll()
-        if (!(projects && projects.length)) return []
-        return projects.filter((e) => e?.external_id === externalId)
+    /**
+     * Retrieves active projects matching the given external ID.
+     *
+     * Overloaded: passing `includeTotals: false` returns `TimelyProjectSummary[]`;
+     * omitting it or passing `true` returns `TimelyProject[]`.
+     */
+    async getByExternalId(externalId: string, includeTotals?: true): Promise<TimelyProject[]>
+    async getByExternalId(externalId: string, includeTotals: false): Promise<TimelyProjectSummary[]>
+    async getByExternalId(
+        externalId: string,
+        includeTotals: boolean = true,
+    ): Promise<TimelyProject[] | TimelyProjectSummary[]> {
+        const { data: projects } = await this.http.get(
+            `/${this.config.accountId}/projects?state=active&external_ids=${externalId}&totals=${includeTotals}`,
+        )
+        return projects
+    }
+
+    /**
+     * Retrieves active projects matching the given project IDs.
+     *
+     * Overloaded: passing `includeTotals: false` returns `TimelyProjectSummary[]`;
+     * omitting it or passing `true` returns `TimelyProject[]`.
+     */
+    async getByProjectIds(projectIds: number[], includeTotals?: true): Promise<TimelyProject[]>
+    async getByProjectIds(
+        projectIds: number[],
+        includeTotals: false,
+    ): Promise<TimelyProjectSummary[]>
+    async getByProjectIds(
+        projectIds: number[],
+        includeTotals: boolean = true,
+    ): Promise<TimelyProject[] | TimelyProjectSummary[]> {
+        const { data: projects } = await this.http.get(
+            `/${this.config.accountId}/projects?state=active&ids=${projectIds.join(
+                ',',
+            )}&totals=${includeTotals}`,
+        )
+        return projects
     }
 
     async add(project: AddTimelyProject): Promise<TimelyProject> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -132,7 +132,7 @@ export interface TimelyLabel {
     children: TimelyLabel[]
 }
 
-export interface TimelyProject {
+export interface TimelyProjectBase {
     id: number
     active: boolean
     account_id: number
@@ -153,12 +153,15 @@ export interface TimelyProject {
     budget_type: string
     hour_rate: number
     hour_rate_in_cents: number
-    budget_progress: number
-    budget_percent: number
     users: TimelyProjectUser[]
     labels: TimelyProjectLabel[]
     label_ids: number[]
     required_label_ids: number[]
+}
+
+export interface TimelyProject extends TimelyProjectBase {
+    budget_progress: number
+    budget_percent: number
     cost: TimelyProjectCost
     estimated_cost: TimelyProjectCost
     duration: TimelyProjectDuration
@@ -168,6 +171,8 @@ export interface TimelyProject {
     unbilled_cost: TimelyProjectCost
     unbilled_duration: TimelyProjectDuration
 }
+
+export type TimelyProjectSummary = TimelyProjectBase
 export interface TimelyProjectDuration {
     hours: number
     minutes: number


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes Timely HTTP query shape (filter→state/totals) and getByExternalId behavior; defaults preserve full totals for getAll/getByExternalId but getArchived now omits totals by default, which may break callers expecting budget fields without passing includeTotals.
> 
> **Overview**
> Refactors the Timely **Projects** client to hit faster list endpoints by sending `state` and `totals` query params instead of `filter`, and adds an optional **`includeTotals`** flag on list helpers so callers can opt into lightweight **`TimelyProjectSummary`** responses when budget/duration fields are not needed.
> 
> **`getByExternalId`** and new **`getByProjectIds`** now query the API directly (`external_ids`, `ids`) instead of loading all projects and filtering in memory. **`getArchived`** defaults to **`totals=false`** for speed (full **`TimelyProject`** only when `includeTotals` is true). Types split shared fields into **`TimelyProjectBase`** / **`TimelyProjectSummary`**, with totals-bearing fields remaining on **`TimelyProject`**. Tests were expanded to assert URL construction and return-type behavior per overload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1850cf2d4a14a68fdea32a2ed6bdeea32cb19dc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->